### PR TITLE
Illustrate the use jsonargparse instead of hydra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-# Configuration Management For Data Science Made Easy With Hydra
-
-This repository contains the example code of the video on Hydra and configurations. Here's the link to the video: https://youtu.be/tEsPyYnzt8.
+# Configuration Management For Data Science Made Easy With jsonargparse

--- a/after/conf/config.yaml
+++ b/after/conf/config.yaml
@@ -1,9 +1,7 @@
-defaults:
-  - files: mnist
-  - _self_
+files: files/mnist.yaml
 paths:
   log: ./runs
-  data: ${hydra:runtime.cwd}/../data/raw
+  data: ../data/raw
 params:
   epoch_count: 20
   lr: 5e-5

--- a/after/config.py
+++ b/after/config.py
@@ -3,6 +3,11 @@ from dataclasses import dataclass
 
 @dataclass
 class Paths:
+    """
+    Args:
+        log: Tensorboard log directory
+        data: Input data directory
+    """
     log: str
     data: str
 
@@ -20,10 +25,3 @@ class Params:
     epoch_count: int
     lr: float
     batch_size: int
-
-
-@dataclass
-class MNISTConfig:
-    paths: Paths
-    files: Files
-    params: Params

--- a/after/defaults.yaml
+++ b/after/defaults.yaml
@@ -1,0 +1,3 @@
+params:
+  epoch_count: 50
+  batch_size: 256

--- a/after/main.py
+++ b/after/main.py
@@ -63,4 +63,4 @@ def main(
 
 
 if __name__ == "__main__":
-    CLI(main)
+    CLI(main, default_config_files=['defaults.yaml'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ tensorboard
 mlflow
 tqdm
 pillow
-hydra-core
+jsonargparse[signatures]


### PR DESCRIPTION
@ArjanCodes @egges thank you very much for your videos! Certainly they have been very useful for me to learn new things.

I created this pull request to show how the same could be done with jsonargparse instead of hydra. Not sure if you would be interested in looking at this, but created it anyway. Each framework has its own advantages and disadvantages which is normal. But I did note that some of the caveats mentioned in the video do not apply with jsonargparse. I commented most of the changes to give more context, so have a look at the [Files changed](https://github.com/mauvilsa/2021-config/pull/1/files).

This pull request only shows minimal changes to your code to use jsonargparse instead of hydra. But there is much more that can be done with it. The [documentation](https://jsonargparse.readthedocs.io/en/stable/) is more or less good. Unfortunately it does lack having example use cases that could help in understanding how to use its features for different kinds of projects.

Also do have a look at the documentation of pytorch-lightning's [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/cli/lightning_cli.html) which is implemented using jsonargparse.